### PR TITLE
fix: Update Gemini API endpoint to stable v1

### DIFF
--- a/netlify/functions/process-text.js
+++ b/netlify/functions/process-text.js
@@ -51,7 +51,7 @@ exports.handler = async function(event, context) {
 ГОТОВЫЙ ПУНКТ СОГЛАШЕНИЯ:`;
 
         // 5. Prepare the request payload for the Gemini API
-        const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`;
+        const apiUrl = `https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent?key=${apiKey}`;
         const payload = {
             contents: [{
                 parts: [{


### PR DESCRIPTION
This commit resolves a 404 Not Found error that occurred when calling the Google Gemini API.

The error was caused by using an outdated `v1beta` endpoint URL in the Netlify function.

This fix updates the `apiUrl` in `netlify/functions/process-text.js` to use the stable `v1` endpoint for the `gemini-pro` model. This ensures that the API requests are sent to the correct, currently active endpoint.