### PR TITLE
fix: Add netlify.toml to configure functions directory

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+# This file configures the deployment settings for Netlify.
+
+[build]
+  # This line specifies the directory where Netlify will find the serverless functions.
+  functions = "netlify/functions"


### PR DESCRIPTION
This commit adds a `netlify.toml` configuration file to the root of the project.

This file is necessary to explicitly tell the Netlify platform where to find the serverless functions for deployment. The lack of this configuration was causing the previously deployed function to return a 404 Not Found error.

The `[build]` context is configured to set the `functions` directory to `netlify/functions`, which resolves the deployment issue.