### PR TITLE
fix: Update Gemini API model to 1.5-flash-latest

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,7 +52,7 @@ app.post('/api/process-text', async (req, res) => {
 ГОТОВЫЙ ПУНКТ СОГЛАШЕНИЯ:`;
 
         // 4. Prepare the request payload for the Gemini API
-        const apiUrl = `https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent?key=${apiKey}`;
+        const apiUrl = `https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`;
         const payload = {
             contents: [{
                 parts: [{


### PR DESCRIPTION
This commit resolves a 404 Not Found error from the Google Gemini API.

The error was caused by using an incorrect model name (`gemini-pro`) for the `v1` API endpoint.

This fix updates the `apiUrl` in `server.js` to use the `gemini-1.5-flash-latest` model, as requested, which is a valid and supported model for the v1 API.